### PR TITLE
fix class checking

### DIFF
--- a/R/assam.R
+++ b/R/assam.R
@@ -276,7 +276,7 @@ assam <- function(y,
     ##----------------
     message("Commencing fitting...")
     if(!is.null(supply_quadapprox)) {
-        if(inherits(supply_quadapprox, "assam_quadapprox"))
+        if(!inherits(supply_quadapprox, "assam_quadapprox"))
             stop("If supply_quadapprox is supplied, then it must be an object of class \"assam_quadapprox\".")
         
         message("Species-specific quadratic approximations supplied by practitioner...thanks!")

--- a/R/quadapprox_fn.R
+++ b/R/quadapprox_fn.R
@@ -12,7 +12,7 @@
     
     num_spp <- ncol(resp)
     if(add_spatial) {
-        if(inherits(mesh, "sdmTMBmesh"))
+        if(!inherits(mesh, "sdmTMBmesh"))
             stop("If mesh is supplied for species-specific spatial fields, then the mesh argument must be an object class of \"sdmTMBmesh\".")
         }
 


### PR DESCRIPTION
This PR is a small fix to the class checking of mesh and will close #14 . I think at some point this was fixed in `assam.R` but not `quadapprox_fn.R`.

While doing so I also found that the class checking of supply_quadapprox needs to be flipped. 