### PR TITLE
specify dobar argument and avoid fitting sdmTMB for model matrix

### DIFF
--- a/R/assam.R
+++ b/R/assam.R
@@ -695,7 +695,8 @@ assam <- function(y,
         message("Mixture component is being emptied...altering initial temp probability and restarting EM-algorithm to try and fix this.")
         control$temper_prob <- control$temper_prob + 0.025
           
-        do_em <- em_fn(qa_object = get_qa)
+        do_em <- em_fn(qa_object = get_qa,
+                       dobar_penalty = beta_selection)
         try_counter <- try_counter + 1
         }
 

--- a/R/predict.assam.R
+++ b/R/predict.assam.R
@@ -107,7 +107,8 @@ predict.assam <- function(object,
         tmp_formula <- as.formula(paste("response", paste(as.character(object$formula),collapse = " ") ) )
         nullfit <- sdmTMB(tmp_formula, 
                           spatial = FALSE,
-                          data = data.frame(newdata, response = rnorm(nrow(newdata)))) #' This may not work in the future if smootihng terms are included, say, due to the standardization that needs to be applied    
+                          data = data.frame(newdata, response = rnorm(nrow(newdata))),
+                          do_fit = FALSE) #' This may not work in the future if smootihng terms are included, say, due to the standardization that needs to be applied    
         X <- model.matrix(nullfit$formula[[1]], data = nullfit$data)
         
         get_eta <- tcrossprod(X[, -object$which_spp_effects, drop = FALSE], object$betas)


### PR DESCRIPTION
This PR is a quick fix to avoid the error: 
```
Mixture component is being emptied...altering initial temp probability and restarting EM-algorithm to try and fix this.
Error in em_fn(qa_object = get_qa) : 
  argument "dobar_penalty" is missing, with no default
```